### PR TITLE
Add markdown as a dependency for docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /_build
+/cover
 /deps
 erl_crash.dump
 *.ez
+/doc

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,10 @@ defmodule Dbg.Mixfile do
   end
 
   defp deps do
-    [{:ex_doc, "~> 0.7", only: [:docs]}]
+    [
+      {:ex_doc, "~> 0.7", only: [:docs]},
+      {:earmark, "~> 0.1", only: [:docs]}
+    ]
   end
 
   defp description do

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,2 @@
+%{"earmark": {:hex, :earmark, "0.1.19"},
+  "ex_doc": {:hex, :ex_doc, "0.11.1"}}


### PR DESCRIPTION
Hey there, I've added a few small tweaks to this package:

 - I added `/cover` and `/doc` to the gitignore
   - `/doc` is generated when `mix docs` is ran
   - `/cover` was the only line missing from [gitignore.io](https://www.gitignore.io/api/elixir)
 - I added the markdown dependency for the docs environment, so that the docs can be compiled.

Thanks

JH