### PR TITLE
fix warning

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,7 @@ defmodule Dbg.Mixfile do
        source_url: "https://github.com/fishcakez/dbg",
        main: Dbg,
      ],
-     deps: deps]
+     deps: deps()]
   end
 
   def application do


### PR DESCRIPTION
fixes the warning: variable "deps" does not exist and is being expanded to "deps()"